### PR TITLE
Resolve bug das parcelas aparecendo como X

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Block/Info.php
+++ b/app/code/community/Uecommerce/Mundipagg/Block/Info.php
@@ -84,8 +84,6 @@ class Uecommerce_Mundipagg_Block_Info extends Mage_Payment_Block_Info {
 	}
 
 	public function getInstallmentsNumber($ccQty, $ccPos) {
-        echo '<pre>';
-
 		if ($ccQty == 1) {
 			$installments = $this
                 ->getInfo()

--- a/app/code/community/Uecommerce/Mundipagg/Block/Info.php
+++ b/app/code/community/Uecommerce/Mundipagg/Block/Info.php
@@ -84,13 +84,37 @@ class Uecommerce_Mundipagg_Block_Info extends Mage_Payment_Block_Info {
 	}
 
 	public function getInstallmentsNumber($ccQty, $ccPos) {
-		if ($ccQty == 1) {
-			$installments = $this->getInfo()->getAdditionalInformation("mundipagg_creditcard_credito_parcelamento_1_1");
-		} else {
-			$installments = $this->getInfo()
-				->getAdditionalInformation("mundipagg_twocreditcards_credito_parcelamento_{$ccQty}_{$ccPos}");
-		}
+        echo '<pre>';
 
+		if ($ccQty == 1) {
+			$installments = $this
+                ->getInfo()
+                ->getAdditionalInformation(
+                    "mundipagg_creditcard_credito_parcelamento_1_1"
+                );
+
+            if (!$installments) {
+			    $installments = $this
+                    ->getInfo()
+                    ->getAdditionalInformation(
+                        "mundipagg_creditcard_new_credito_parcelamento_1_1"
+                    );
+            }
+		} else {
+			$installments = $this
+                ->getInfo()
+				->getAdditionalInformation(
+                    "mundipagg_twocreditcards_credito_parcelamento_{$ccQty}_{$ccPos}"
+                );
+
+            if (!$installments) {
+			    $installments = $this
+                    ->getInfo()
+				    ->getAdditionalInformation(
+                        "mundipagg_twocreditcards_new_credito_parcelamento_{$ccQty}_{$ccPos}"
+                    );
+            }
+		}
 
 		$installments .= "x";
 


### PR DESCRIPTION
**What?**
O número de parcelas aparecia como x para novos cartões

**Why?**
O método que retornava a quantidade de parcelas ignorava a existência de novos cartões

**How?**
Foi modificado o método getInstallmentsNumber, do arquivo de bloco Info.php e agora o método também leva em consideração novos cartões.
