### PR TITLE
feature: void after complete

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Model/Api.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Api.php
@@ -1294,12 +1294,29 @@ class Uecommerce_Mundipagg_Model_Api extends Uecommerce_Mundipagg_Model_Standard
 				//if Magento order is not processing and MundiPagg order status is canceled, cancel the order on Magento
 				if ($order->getState() != Mage_Sales_Model_Order::STATE_PROCESSING && $orderStatus == Uecommerce_Mundipagg_Model_Enum_OrderStatusEnum::CANCELED) {
 
-					if ($order->getState() == Mage_Sales_Model_Order::STATE_CANCELED) {
-						$returnMessage = "OK | {$returnMessageLabel} | Order already canceled.";
+					switch ($order->getState()) {
+						case Mage_Sales_Model_Order::STATE_CANCELED:
+							$returnMessage = "OK | {$returnMessageLabel} | Order already canceled.";
+							$helperLog->info($returnMessage);
+							return $returnMessage;
+						case Mage_Sales_Model_Order::STATE_COMPLETE:
+							foreach ($order->getInvoiceCollection() as $invoice) {
+								if ($invoice->canRefund()) {
+									$invoices[] = $invoice;
+								}
+							}
 
-						$helperLog->info($returnMessage);
-
-						return $returnMessage;
+							if (!empty($invoices)) {
+								$service = Mage::getModel('sales/service_order', $order);
+								foreach ($invoices as $invoice) {
+									$this->closeInvoice($invoice);
+									$this->createCreditMemo($invoice, $service);
+								}
+							}
+							$this->closeOrder($order);
+							$returnMessage = 'OK | ' . $returnMessageLabel . ' | Order closed.';
+							$helperLog->info($returnMessage);
+							return $returnMessage;
 					}
 
 					try {

--- a/app/code/community/Uecommerce/Mundipagg/Model/Api.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Api.php
@@ -1296,7 +1296,7 @@ class Uecommerce_Mundipagg_Model_Api extends Uecommerce_Mundipagg_Model_Standard
 
 					switch ($order->getState()) {
 						case Mage_Sales_Model_Order::STATE_CANCELED:
-							$returnMessage = "OK | {$returnMessageLabel} | Order already canceled.";
+							$returnMessage = 'OK | ' . $returnMessageLabel . ' | Order already canceled.';
 							$helperLog->info($returnMessage);
 							return $returnMessage;
 						case Mage_Sales_Model_Order::STATE_COMPLETE:


### PR DESCRIPTION
What?
Change status to closed after status complete when receive a voided
notification post.

Why?
When the order has status complete, before this pull request, don't is possible close the order (refund).