### PR TITLE
Fix bug with variable totals

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Model/Quote/Address/Interest.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Quote/Address/Interest.php
@@ -48,7 +48,7 @@ class Uecommerce_Mundipagg_Model_Quote_Address_Interest extends Mage_Sales_Model
 
         $this->_setAddress($address);
         $addressObj = $this->_getAddress();
-        $totals = $addressObj->$_totals;
+        $totals = $addressObj->_totals;
         
         parent::collect($address);
 


### PR DESCRIPTION
# What?
At some point, we let a wrong reference to a variable be inserted in the project. Magento kept trying to use the $this->$_totals (instead of $this->_totals, how could this work? Oo) which was slowing down the checkout performance.