### PR TITLE
:bug: Verify if boleto's url exists.

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Block/Standard/Success.php
+++ b/app/code/community/Uecommerce/Mundipagg/Block/Standard/Success.php
@@ -177,24 +177,15 @@ class Uecommerce_Mundipagg_Block_Standard_Success extends Mage_Sales_Block_Items
      **/
     public function getBoletoUrl()
     {
-        $customerSession = Mage::getSingleton('customer/session');
-        $orders = Mage::getModel('sales/order')
-            ->getCollection()
-            ->addFieldToFilter('customer_id', $customerSession->getId())
-            ->addFieldToFilter('increment_id', $this->_getData('order_id'));
-
-        $ordersFound = count($orders);
-
-        if ($ordersFound == 1) {
+        if (!empty($this->_getData('boleto_url'))) {
             return $this->_getData('boleto_url');
         } else {
+            $customerSession = Mage::getSingleton('customer/session');
             $helperLog = new Uecommerce_Mundipagg_Helper_Log(__METHOD__);
-            $api = new Uecommerce_Mundipagg_Model_Api();
             $orderId = $this->_getData('order_id');
             $errMsg = "Order #{$orderId} don't belongs to customer {$customerSession->getId()}. Boleto url won't be showed on success.phtml";
 
             $helperLog->error($errMsg);
-            $api->mailError($errMsg);
 
             return false;
         }


### PR DESCRIPTION
# What
Fix guest order without boleto's url.

# Why
When a guest order is placed an error occurs hiding boleto's url.

# How
Now the verification is about 'boleto_url' variable and not validate order proprieties  anymore.